### PR TITLE
Fix uploader script

### DIFF
--- a/src/faraday.sh
+++ b/src/faraday.sh
@@ -14,7 +14,8 @@ faraday::create_workspace() {
   local FARADAY_WORKSPACE=$1
 
   echo "Creating workspace $FARADAY_WORKSPACE if it doesn't exists"
-  faraday-cli create_ws $FARADAY_WORKSPACE
+  faraday-cli workspace create $FARADAY_WORKSPACE
+  faraday-cli workspace select $FARADAY_WORKSPACE
   echo "Workspace $FARADAY_WORKSPACE created/selected successfully"
 }
 
@@ -23,7 +24,7 @@ faraday::upload_report() {
   local FARADAY_REPORT_FILENAME=$2
 
   echo "Uploading report to $FARADAY_WORKSPACE"
-  faraday-cli process_report -w $FARADAY_WORKSPACE $FARADAY_REPORT_FILENAME
+  faraday-cli tool report $FARADAY_REPORT_FILENAME
 
   echo "Faraday import finished successfully"
 }


### PR DESCRIPTION
The uploader script no longer works, probably because of changes in `faraday-cli` syntax.

I tried using it and got the following errors:

```bash
Running the process...
Executing Faraday import
Authenticating in Faraday
Saving config
✔ Authenticated with faraday: [REDACTED]
Creating workspace [REDACTED] if it doesn't exists
sh: 1: create_ws: not found
Workspace [REDACTED] created/selected successfully
Uploading report to [REDACTED]
sh: 1: process_report: not found
Faraday import finished successfully
```

So, I wrote and tested this quick fix.
Hope it helps.

